### PR TITLE
Adding win32 makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+PROG = tbftss
+CC = gcc
+CXXFLAGS += -DUNIX
+
+include common.mk

--- a/Makefile.win32
+++ b/Makefile.win32
@@ -1,0 +1,4 @@
+PROG = tbftss.exe
+CC=x86_64-w64-mingw32-gcc
+
+include common.mk

--- a/common.mk
+++ b/common.mk
@@ -4,9 +4,8 @@ VERSION = 0.4
 REVISION = $(shell date +"%y%m%d")
 DEBUG = 0
 
-CXXFLAGS += `sdl2-config --cflags` -DVERSION=$(VERSION) -DREVISION=$(REVISION) -DUNIX=1 -DDEBUG=$(DEBUG)
-CXXFLAGS += -DUNIX
-CXXFLAGS += $(CFLAGS) -Wall -ansi -pedantic -Werror -Wstrict-prototypes
+CXXFLAGS += `sdl2-config --cflags` -DVERSION=$(VERSION) -DREVISION=$(REVISION) -DDEBUG=$(DEBUG)
+CXXFLAGS += -Wall -ansi -pedantic -Werror -Wstrict-prototypes
 CXXFLAGS += -g -lefence
 
 LIBS = `sdl2-config --libs` -lSDL2_mixer -lSDL2_image -lSDL2_ttf -lm
@@ -43,12 +42,12 @@ all: $(PROG)
 
 # compiling other source files.
 %.o: %.c %.h $(DEPS)
-	$(CC) $(CXXFLAGS) -c $<
+	$(CC) $(CFLAGS) $(CXXFLAGS) -c $<
 
 # linking the program.
 $(PROG): $(OBJS)
 	$(CC)  -o $(PROG) $(OBJS) $(LIBS)
-	
+
 # prepare an archive for the program
 dist:
 	$(RM) -rf $(PROG)-$(VERSION)

--- a/src/structs.h
+++ b/src/structs.h
@@ -18,7 +18,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 */
 
-typedef struct SDL_Texture SDL_Texture;
+struct SDL_Texture;
 typedef struct Texture Texture;
 typedef struct Lookup Lookup;
 typedef struct Weapon Weapon;
@@ -43,7 +43,7 @@ typedef struct {
 struct Texture {
 	char name[MAX_DESCRIPTION_LENGTH];
 	long hash;
-	SDL_Texture *texture;
+	struct SDL_Texture *texture;
 	Texture *next;
 };
 
@@ -115,7 +115,7 @@ struct Entity {
 	Entity *owner;
 	void (*action)(void);
 	void (*die)(void);
-	SDL_Texture *texture;
+	struct SDL_Texture *texture;
 	Entity *next;
 };
 

--- a/src/system/init.c
+++ b/src/system/init.c
@@ -21,7 +21,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "init.h"
 
 
+#if UNIX
 static void createSaveFolder(void);
+#endif
 static void loadConfig(void);
 void saveConfig(void);
 static void initColor(SDL_Color *c, int r, int g, int b);


### PR DESCRIPTION
Added a new Makefile.win32 that builds the game with MinGW64. This requires some small source fixes but the UNIX build should be unaffected.

Windows executable starts so long as freetype and the SDL DLL's are in the EXE folder. The game crashes before any window comes up however, I'm guessing due to some unchecked error relating to some OS dependent behavior.