### PR TITLE
Add support for DESTDIR variable

### DIFF
--- a/makefile
+++ b/makefile
@@ -23,7 +23,7 @@ CXXFLAGS += `sdl2-config --cflags` -DVERSION=$(VERSION) -DREVISION=$(REVISION) -
 CXXFLAGS += -Wall -Wempty-body -ansi -pedantic -Werror -Wstrict-prototypes
 CXXFLAGS += -g -lefence
 
-LFLAGS := `sdl2-config --libs` -lSDL2_mixer -lSDL2_image -lSDL2_ttf -lm
+LFLAGS := `sdl2-config --libs` -lSDL2_mixer -lSDL2_image -lSDL2_ttf -lm $(LDFLAGS)
 
 DIST_FILES = data gfx manual music sound src LICENSE makefile* common.mk README.md CHANGELOG
 

--- a/makefile
+++ b/makefile
@@ -1,10 +1,18 @@
 PROG = tbftss
 CC = gcc
-BIN_DIR = /usr/bin
-DATA_DIR = /opt/tbftss
-LOCALE_DIR = /usr/share/locale
-ICON_DIR = /usr/share/icons/hicolor
-DESKTOP_DIR = /usr/share/applications
+PREFIX ?= /usr/local
+BIN_DIR ?= $(PREFIX)/bin
+DATA_DIR ?= $(PREFIX)/share/$(PROG)
+LOCALE_DIR = $(PREFIX)/share/locale
+ICON_DIR = $(PREFIX)/share/icons/hicolor
+DESKTOP_DIR = $(PREFIX)/share/applications
+
+DESTDIR ?=
+INST_BIN_DIR = $(DESTDIR)$(BIN_DIR)
+INST_DATA_DIR = $(DESTDIR)$(DATA_DIR)
+INST_LOCALE_DIR = $(DESTDIR)$(LOCALE_DIR)
+INST_ICON_DIR = $(DESTDIR)$(ICON_DIR)
+INST_DESKTOP_DIR = $(DESTDIR)$(DESKTOP_DIR)
 
 SEARCHPATH += src/plat/unix
 OBJS += unixInit.o
@@ -24,37 +32,40 @@ $(PROG): $(OBJS)
 	$(CC) -o $@ $(OBJS) $(LFLAGS)
 
 install:
-	cp $(PROG) $(BIN_DIR)
-	mkdir -p $(DATA_DIR)
-	cp -r data $(DATA_DIR)
-	cp -r gfx $(DATA_DIR)
-	cp -r manual $(DATA_DIR)
-	cp -r music $(DATA_DIR)
-	cp -r sound $(DATA_DIR)
-	cp -p icons/$(PROG)-16x16.png $(ICON_DIR)/16x16/apps/$(PROG).png
-	cp -p icons/$(PROG)-32x32.png $(ICON_DIR)/32x32/apps/$(PROG).png
-	cp -p icons/$(PROG)-64x64.png $(ICON_DIR)/64x64/apps/$(PROG).png
-	cp -p icons/$(PROG)-128x128.png $(ICON_DIR)/128x128/apps/$(PROG).png
-	cp -p icons/$(PROG).desktop $(DESKTOP_DIR)
+	install -d $(INST_BIN_DIR)
+	install -m 0755 $(PROG) $(INST_BIN_DIR)
+	install -d $(INST_DATA_DIR)
+	cp -r data $(INST_DATA_DIR)
+	cp -r gfx $(INST_DATA_DIR)
+	cp -r manual $(INST_DATA_DIR)
+	cp -r music $(INST_DATA_DIR)
+	cp -r sound $(INST_DATA_DIR)
+	install -d $(INST_ICON_DIR)/{16x16,32x32,64x64,128x128}/apps
+	cp -p icons/$(PROG)-16x16.png $(INST_ICON_DIR)/16x16/apps/$(PROG).png
+	cp -p icons/$(PROG)-32x32.png $(INST_ICON_DIR)/32x32/apps/$(PROG).png
+	cp -p icons/$(PROG)-64x64.png $(INST_ICON_DIR)/64x64/apps/$(PROG).png
+	cp -p icons/$(PROG)-128x128.png $(INST_ICON_DIR)/128x128/apps/$(PROG).png
+	install -d $(INST_DESKTOP_DIR)
+	cp -p icons/$(PROG).desktop $(INST_DESKTOP_DIR)
 	
 	@for f in $(LOCALE_MO); do \
 		lang=`echo $$f | sed -e 's/^locale\///;s/\.mo$$//'`; \
-		mkdir -p $(LOCALE_DIR)/$$lang/LC_MESSAGES; \
-		cp -v $$f $(LOCALE_DIR)/$$lang/LC_MESSAGES/$(PROG).mo; \
+		install -d $(INST_LOCALE_DIR)/$$lang/LC_MESSAGES; \
+		cp -v $$f $(INST_LOCALE_DIR)/$$lang/LC_MESSAGES/$(PROG).mo; \
 	done
 	
 uninstall:
-	$(RM) $(BIN_DIR)/$(PROG)
-	$(RM) -rf $(DATA_DIR)
-	$(RM) $(ICON_DIR)/16x16/apps/$(PROG).png
-	$(RM) $(ICON_DIR)/32x32/apps/$(PROG).png
-	$(RM) $(ICON_DIR)/64x64/apps/$(PROG).png
-	$(RM) $(ICON_DIR)/128x128/apps/$(PROG).png
-	$(RM) $(DESKTOP_DIR)/$(PROG).desktop
+	$(RM) $(INST_BIN_DIR)/$(PROG)
+	$(RM) -rf $(INST_DATA_DIR)
+	$(RM) $(INST_ICON_DIR)/16x16/apps/$(PROG).png
+	$(RM) $(INST_ICON_DIR)/32x32/apps/$(PROG).png
+	$(RM) $(INST_ICON_DIR)/64x64/apps/$(PROG).png
+	$(RM) $(INST_ICON_DIR)/128x128/apps/$(PROG).png
+	$(RM) $(INST_DESKTOP_DIR)/$(PROG).desktop
 	
 	@for f in $(LOCALE_MO); do \
 		lang=`echo $$f | sed -e 's/^locale\///;s/\.mo$$//'`; \
-		$(RM) -v $(LOCALE_DIR)/$$lang/LC_MESSAGES/$(PROG).mo; \
+		$(RM) -v $(INST_LOCALE_DIR)/$$lang/LC_MESSAGES/$(PROG).mo; \
 	done
 
 # prepare an archive for the program


### PR DESCRIPTION
This allows (among others) packagers to install the files in a temporary
folder to generate a RPM or DEB file. The `DESTDIR` variable is a well
established convention for this.

This commit also adds the possibility to override the installation `PREFIX`,
`BIN_DIR` and `DATA_DIR` (as some distros would prefer `/usr/games` for the binary
and `/usr/share/games/tbftss` for the data).

This commit also makes the default `DATA_DIR` `/usr/local/share/tbftss`, if you prefer to keep `/opt/tbftss` for this purpose I could change it back.