### PR TITLE
Makefile: Honor environment LDFLAGS

### DIFF
--- a/makefile
+++ b/makefile
@@ -23,7 +23,7 @@ CXXFLAGS += `sdl2-config --cflags` -DVERSION=$(VERSION) -DREVISION=$(REVISION) -
 CXXFLAGS += -Wall -Wempty-body -ansi -pedantic -Werror -Wstrict-prototypes -Werror=maybe-uninitialized -Warray-bounds
 CXXFLAGS += -g -lefence
 
-LFLAGS := `sdl2-config --libs` -lSDL2_mixer -lSDL2_image -lSDL2_ttf -lm
+LDFLAGS += `sdl2-config --libs` -lSDL2_mixer -lSDL2_image -lSDL2_ttf -lm
 
 SHARED_FILES = CHANGELOG LICENSE README.md data gfx manual music sound icons
 DIST_FILES = $(SHARED_FILES) locale tbftss
@@ -31,7 +31,7 @@ SRC_DIST_FILES = $(SHARED_FILES) src makefile* common.mk
 
 # linking the program.
 $(PROG): $(OBJS)
-	$(CC) -o $@ $(OBJS) $(LFLAGS)
+	$(CC) -o $@ $(OBJS) $(LDFLAGS)
 
 install:
 	mkdir -p $(INST_BIN_DIR)

--- a/makefile.pandora
+++ b/makefile.pandora
@@ -13,13 +13,13 @@ CXXFLAGS += `sdl2-config --cflags` -DVERSION=$(VERSION) -DREVISION=$(REVISION) -
 CXXFLAGS += -ansi -Wstrict-prototypes
 CXXFLAGS += -g -lefence -flto -flto-odr-type-merging
 
-LFLAGS := `sdl2-config --libs` -lSDL2_mixer -lSDL2_image -lSDL2_ttf -lm
+LDFLAGS += `sdl2-config --libs` -lSDL2_mixer -lSDL2_image -lSDL2_ttf -lm
 
 DIST_FILES = data gfx manual music sound src LICENSE makefile* common.mk README.md CHANGELOG
 
 # linking the program.
 $(PROG): $(OBJS)
-	$(CC) -o $@ $(OBJS) $(LFLAGS)
+	$(CC) -o $@ $(OBJS) $(LDFLAGS)
 
 install:
 	cp $(PROG) $(BIN_DIR)

--- a/makefile.win32
+++ b/makefile.win32
@@ -10,10 +10,10 @@ OBJS += win32Init.o
 CXXFLAGS += `$(SDLC) --cflags` -DVERSION=$(VERSION) -DREVISION=$(REVISION) -DDATA_DIR=\"$(DATA_DIR)\" -DLOCALE_DIR=\"$(LOCALE_DIR)\"
 CXXFLAGS += -ansi
 
-LFLAGS = `$(SDLC) --libs` -lm -lSDL2_mixer -lSDL2_image -lSDL2_ttf -lSDL2main
+LDFLAGS += `$(SDLC) --libs` -lm -lSDL2_mixer -lSDL2_image -lSDL2_ttf -lSDL2main
 
 include common.mk
 
 # linking the program.
 $(PROG): $(OBJS)
-	$(CC) -o $@ $(OBJS) $(LFLAGS) -L$(LIBPATH)
+	$(CC) -o $@ $(OBJS) $(LDFLAGS) -L$(LIBPATH)


### PR DESCRIPTION
- Changes the linking flags variable to `LDFLAGS`, which is the most widely used identifier for it in Makefile/autotools, etc.
- Append to it so that `LDFLAGS` can be defined in the environment to prepend custom linking flags (as done with `CXXFLAGS`).