### PR TITLE
Prevent readFile from returning uninitialized pointer on fopen() failure.

### DIFF
--- a/src/system/io.c
+++ b/src/system/io.c
@@ -44,7 +44,7 @@ char *getFileLocation(char *filename)
 
 char *readFile(char *filename)
 {
-	char *buffer;
+	char *buffer = NULL;
 	long length;
 	FILE *file;
 


### PR DESCRIPTION

Signed-off-by: Stephen M. Cameron <stephenmcameron@gmail.com>