### PR TITLE
`tophyId` fix

### DIFF
--- a/src/game/trophies.c
+++ b/src/game/trophies.c
@@ -426,7 +426,8 @@ void awardStatsTrophies(void)
 
 void awardCampaignTrophies(void)
 {
-	char trophyId[MAX_NAME_LENGTH];
+	/* add 9 to MAX_NAME_LENGTH to account for "CAMPAIGN_" */
+	char trophyId[MAX_NAME_LENGTH+9];
 	char name[MAX_NAME_LENGTH];
 	int i, len;
 	StarSystem *starSystem;


### PR DESCRIPTION
When compiling, it would throw `src/game/trophies.c:455:32: error: ‘%s’ directive writing up to 31 bytes into a region of size 23`. Fixed by adding 9 to `MAX_NAME_LENGTH` to account for "CAMPAIGN_".