### PR TITLE
Add controller support

### DIFF
--- a/data/app/config.json
+++ b/data/app/config.json
@@ -32,6 +32,20 @@
 			"CONTROL_PREV_FIGHTER" : 4,
 			"CONTROL_NEXT_FIGHTER" : 5,
 			"CONTROL_SCREENSHOT" : 0
+		},
+		"controller" : 	{
+			"CONTROL_FIRE" : { "axis" : 1, "value" : 5},
+			"CONTROL_ACCELERATE" : { "axis" : 0, "value" : 0},
+			"CONTROL_BOOST" : { "axis" : 0, "value" : 1},
+			"CONTROL_ECM" : { "axis" : 0, "value" : 2},
+			"CONTROL_BRAKE" : { "axis" : 0, "value" : 3},
+			"CONTROL_TARGET" : { "axis" : 1, "value" : 4},
+			"CONTROL_MISSILE" : { "axis" : 0, "value" : 9},
+			"CONTROL_GUNS" : { "axis" : 0, "value" : 10},
+			"CONTROL_RADAR" : { "axis" : 0, "value" : 11},
+			"CONTROL_PREV_FIGHTER" : { "axis" : 0, "value" : 13},
+			"CONTROL_NEXT_FIGHTER" : { "axis" : 0, "value" : 14},
+			"CONTROL_SCREENSHOT" : { "axis" : 0, "value" : 4}
 		}
 	},
 	"gameplay" : {

--- a/src/battle/battle.c
+++ b/src/battle/battle.c
@@ -396,15 +396,23 @@ static void handleController(void)
 		}
 		app.controllerX += app.controllerAxis[0] / 4;
 		if (app.controllerX < 0)
+		{
 			app.controllerX = 0;
+		}
 		else if (app.controllerX > app.winWidth)
+		{
 			app.controllerX = app.winWidth;
+		}
 		app.uiMouse.x = app.controllerX - app.uiOffset.x;
 		app.controllerY += app.controllerAxis[1] / 4;
 		if (app.controllerY < 0)
+		{
 			app.controllerY = 0;
+		}
 		else if (app.controllerY > app.winHeight)
+		{
 			app.controllerY = app.winHeight;
+		}
 		app.uiMouse.y = app.controllerY - app.uiOffset.y;
 	}
 }

--- a/src/battle/battle.c
+++ b/src/battle/battle.c
@@ -67,6 +67,7 @@ extern Game    game;
 static void logic(void);
 static void draw(void);
 static void handleKeyboard(void);
+static void handleController(void);
 static void postBattle(void);
 static void doBattle(void);
 static void optQuitBattle(void);
@@ -145,6 +146,8 @@ void initBattle(void)
 
 static void logic(void)
 {
+	handleController();
+
 	if (battle.status == MS_IN_PROGRESS || battle.status == MS_COMPLETE || battle.status == MS_FAILED || battle.status == MS_TIME_UP)
 	{
 		handleKeyboard();
@@ -344,7 +347,7 @@ static void drawMenu(void)
 
 static void handleKeyboard(void)
 {
-	if (app.keyboard[SDL_SCANCODE_ESCAPE] && !app.awaitingWidgetInput && battle.status == MS_IN_PROGRESS)
+	if ((app.keyboard[SDL_SCANCODE_ESCAPE] || app.controllerStart) && !app.awaitingWidgetInput && battle.status == MS_IN_PROGRESS)
 	{
 		switch (show)
 		{
@@ -367,6 +370,7 @@ static void handleKeyboard(void)
 		}
 
 		clearInput();
+		app.controllerStart = 0;
 
 		playSound(SND_GUI_CLOSE);
 	}
@@ -378,6 +382,30 @@ static void handleKeyboard(void)
 		selectWidget("ok", "startBattle");
 
 		SDL_SetWindowGrab(app.window, 0);
+	}
+}
+
+static void handleController(void)
+{
+	if ((app.controllerAxis[0] != 0) || (app.controllerAxis[0] != 0) || (app.controllerAxis[0] != 0) || (app.controllerAxis[0] != 0))
+	{
+		if (app.controllerX == CONTROLLER_NOINPUT)
+		{
+			app.controllerX = app.mouse.x;
+			app.controllerY = app.mouse.y;
+		}
+		app.controllerX += app.controllerAxis[0] / 4;
+		if (app.controllerX < 0)
+			app.controllerX = 0;
+		else if (app.controllerX > app.winWidth)
+			app.controllerX = app.winWidth;
+		app.uiMouse.x = app.controllerX - app.uiOffset.x;
+		app.controllerY += app.controllerAxis[1] / 4;
+		if (app.controllerY < 0)
+			app.controllerY = 0;
+		else if (app.controllerY > app.winHeight)
+			app.controllerY = app.winHeight;
+		app.uiMouse.y = app.controllerY - app.uiOffset.y;
 	}
 }
 

--- a/src/battle/player.c
+++ b/src/battle/player.c
@@ -400,6 +400,7 @@ static void handleMouse(void)
 			preFireMissile();
 
 			app.mouse.button[SDL_BUTTON_MIDDLE] = 0;
+			app.controllerButton[CONTROL_MISSILE] = 0;
 		}
 
 		if (isControl(CONTROL_GUNS))
@@ -407,6 +408,7 @@ static void handleMouse(void)
 			switchGuns();
 
 			app.mouse.button[SDL_BUTTON_X1] = 0;
+			app.controllerButton[CONTROL_GUNS] = 0;
 		}
 
 		if (isControl(CONTROL_RADAR))
@@ -414,6 +416,7 @@ static void handleMouse(void)
 			cycleRadarZoom();
 
 			app.mouse.button[SDL_BUTTON_X2] = 0;
+			app.controllerButton[CONTROL_RADAR] = 0;
 		}
 	}
 }
@@ -425,7 +428,14 @@ static void faceMouse(void)
 
 	x = player->x - battle.camera.x;
 	y = player->y - battle.camera.y;
-	wantedAngle = getAngle(x, y, app.mouse.x, app.mouse.y);
+	if (app.controller)
+	{
+		wantedAngle = getAngle(0, 0, app.controllerAxis[0], app.controllerAxis[1]);
+	}
+	else
+	{
+		wantedAngle = getAngle(x, y, app.mouse.x, app.mouse.y);
+	}
 
 	wantedAngle %= 360;
 

--- a/src/battle/player.c
+++ b/src/battle/player.c
@@ -428,7 +428,7 @@ static void faceMouse(void)
 
 	x = player->x - battle.camera.x;
 	y = player->y - battle.camera.y;
-	if (app.controller)
+	if (app.controllerX != CONTROLLER_NOINPUT)
 	{
 		wantedAngle = getAngle(0, 0, app.controllerAxis[0], app.controllerAxis[1]);
 	}

--- a/src/challenges/challengeHome.c
+++ b/src/challenges/challengeHome.c
@@ -58,6 +58,7 @@ extern Game   game;
 static void  logic(void);
 static void  draw(void);
 static void  handleKeyboard(void);
+static void  handleController(void);
 static void  drawChallenges(void);
 static void  doChallengeList(void);
 static void  startChallengeMission(void);
@@ -228,6 +229,8 @@ static void unlockChallenges(void)
 
 static void logic(void)
 {
+	handleController();
+
 	handleKeyboard();
 
 	scrollBackground(-0.25, 0);
@@ -561,7 +564,7 @@ static void quit(void)
 
 static void handleKeyboard(void)
 {
-	if (app.keyboard[SDL_SCANCODE_ESCAPE] && !app.awaitingWidgetInput)
+	if ((app.keyboard[SDL_SCANCODE_ESCAPE] || app.controllerButton[CONTROL_BOOST]) && !app.awaitingWidgetInput)
 	{
 		switch (show)
 		{
@@ -587,6 +590,31 @@ static void handleKeyboard(void)
 		playSound(SND_GUI_CLOSE);
 
 		clearInput();
+		app.controllerButton[CONTROL_BOOST] = 0;
+	}
+}
+
+static void handleController(void)
+{
+	if ((app.controllerAxis[0] != 0) || (app.controllerAxis[0] != 0) || (app.controllerAxis[0] != 0) || (app.controllerAxis[0] != 0))
+	{
+		if (app.controllerX == CONTROLLER_NOINPUT)
+		{
+			app.controllerX = app.mouse.x;
+			app.controllerY = app.mouse.y;
+		}
+		app.controllerX += app.controllerAxis[0] / 4;
+		if (app.controllerX < 0)
+			app.controllerX = 0;
+		else if (app.controllerX > app.winWidth)
+			app.controllerX = app.winWidth;
+		app.uiMouse.x = app.controllerX - app.uiOffset.x;
+		app.controllerY += app.controllerAxis[1] / 4;
+		if (app.controllerY < 0)
+			app.controllerY = 0;
+		else if (app.controllerY > app.winHeight)
+			app.controllerY = app.winHeight;
+		app.uiMouse.y = app.controllerY - app.uiOffset.y;
 	}
 }
 

--- a/src/challenges/challengeHome.c
+++ b/src/challenges/challengeHome.c
@@ -605,15 +605,23 @@ static void handleController(void)
 		}
 		app.controllerX += app.controllerAxis[0] / 4;
 		if (app.controllerX < 0)
+		{
 			app.controllerX = 0;
+		}
 		else if (app.controllerX > app.winWidth)
+		{
 			app.controllerX = app.winWidth;
+		}
 		app.uiMouse.x = app.controllerX - app.uiOffset.x;
 		app.controllerY += app.controllerAxis[1] / 4;
 		if (app.controllerY < 0)
+		{
 			app.controllerY = 0;
+		}
 		else if (app.controllerY > app.winHeight)
+		{
 			app.controllerY = app.winHeight;
+		}
 		app.uiMouse.y = app.controllerY - app.uiOffset.y;
 	}
 }

--- a/src/defs.h
+++ b/src/defs.h
@@ -156,6 +156,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define AIF_SURRENDERING    (2 << 22)
 #define AIF_SURRENDERED     (2 << 23)
 
+#define CONTROLLER_NOINPUT -512
+
 /* player abilities */
 #define BOOST_RECHARGE_TIME (FPS * 7)
 #define BOOST_FINISHED_TIME (FPS * 0.75)

--- a/src/galaxy/galacticMap.c
+++ b/src/galaxy/galacticMap.c
@@ -58,6 +58,7 @@ static void     logic(void);
 static void     draw(void);
 static void     handleKeyboard(void);
 static void     handleMouse(void);
+static void     handleController(void);
 static void     scrollGalaxy(void);
 static void     drawStarSystemDetail(void);
 static void     selectStarSystem(void);
@@ -232,6 +233,8 @@ static void updatePandoranAdvance(void)
 
 static void logic(void)
 {
+	handleController();
+
 	handleKeyboard();
 
 	handleMouse();
@@ -279,8 +282,16 @@ static void doStarSystems(void)
 
 	if (!scrollingMap)
 	{
-		cx = app.mouse.x - 32;
-		cy = app.mouse.y - 32;
+		if (app.controllerX == CONTROLLER_NOINPUT)
+		{
+			cx = app.mouse.x - 32;
+			cy = app.mouse.y - 32;
+		}
+		else
+		{
+			cx = app.controllerX - 32;
+			cy = app.controllerY - 32;
+		}
 
 		cameraMin.x = cameraMin.y = 99999;
 		cameraMax.x = cameraMax.y = -99999;
@@ -301,11 +312,12 @@ static void doStarSystems(void)
 				{
 					selectedStarSystem = starSystem;
 
-					if (app.mouse.button[SDL_BUTTON_LEFT])
+					if (app.mouse.button[SDL_BUTTON_LEFT] || app.controllerButton[CONTROL_ACCELERATE])
 					{
 						selectStarSystem();
 
 						app.mouse.button[SDL_BUTTON_LEFT] = 0;
+						app.controllerButton[CONTROL_ACCELERATE] = 0;
 					}
 				}
 			}
@@ -330,14 +342,28 @@ static void scrollGalaxy(void)
 
 	if (scrollingMap)
 	{
-		camera.x -= app.mouse.dx * 1.5;
-		camera.y -= app.mouse.dy * 1.5;
+		if (app.controllerX == CONTROLLER_NOINPUT)
+		{
+			camera.x -= app.mouse.dx * 1.5;
+			camera.y -= app.mouse.dy * 1.5;
 
-		ssx = -app.mouse.dx;
-		ssx /= 3;
+			ssx = -app.mouse.dx;
+			ssx /= 3;
 
-		ssy = -app.mouse.dy;
-		ssy /= 3;
+			ssy = -app.mouse.dy;
+			ssy /= 3;
+		}
+		else
+		{
+			camera.x -= app.controllerAxis[2] * 1.5;
+			camera.y -= app.controllerAxis[3] * 1.5;
+
+			ssx = -app.controllerAxis[2];
+			ssx /= 3;
+
+			ssy = -app.controllerAxis[3];
+			ssy /= 3;
+		}
 
 		camera.x = MAX(cameraMin.x, MIN(camera.x, cameraMax.x));
 		camera.y = MAX(cameraMin.y, MIN(camera.y, cameraMax.y));
@@ -364,7 +390,7 @@ static void doStarSystemView(void)
 		{
 			hoverMission = mission;
 
-			if (app.mouse.button[SDL_BUTTON_LEFT])
+			if (app.mouse.button[SDL_BUTTON_LEFT] || app.controllerButton[CONTROL_ACCELERATE])
 			{
 				if (game.currentMission != mission)
 				{
@@ -378,7 +404,7 @@ static void doStarSystemView(void)
 	}
 
 	/* allow closing by pressing the right mouse button */
-	if (app.mouse.button[SDL_BUTTON_RIGHT])
+	if (app.mouse.button[SDL_BUTTON_RIGHT] || app.controllerButton[CONTROL_BOOST])
 	{
 		show = SHOW_GALAXY;
 
@@ -779,7 +805,7 @@ static void campaignCompleteOK(void)
 
 static void handleKeyboard(void)
 {
-	if (app.keyboard[SDL_SCANCODE_ESCAPE] && !app.awaitingWidgetInput)
+	if ((app.keyboard[SDL_SCANCODE_ESCAPE] || app.controllerButton[CONTROL_BOOST]) && !app.awaitingWidgetInput)
 	{
 		switch (show)
 		{
@@ -804,6 +830,7 @@ static void handleKeyboard(void)
 				selectWidget("resume", "galacticMap");
 				break;
 		}
+		app.controllerButton[CONTROL_BOOST] = 0;
 
 		playSound(SND_GUI_CLOSE);
 
@@ -813,19 +840,45 @@ static void handleKeyboard(void)
 
 static void handleMouse(void)
 {
-	if (app.mouse.button[SDL_BUTTON_LEFT])
+	if ((app.mouse.button[SDL_BUTTON_LEFT]) || ((app.controllerX != CONTROLLER_NOINPUT) && (app.controllerAxis[2] != 0 || app.controllerAxis[3] != 0)))
 	{
-		if (app.mouse.dx != 0 || app.mouse.dy != 0)
+		if (app.mouse.dx != 0 || app.mouse.dy != 0 || app.controllerAxis[2] != 0 || app.controllerAxis[3] != 0)
 		{
 			scrollingMap = 1;
 		}
+
+		setMouseCursor(app.mouse.button[SDL_BUTTON_LEFT] && show == SHOW_GALAXY);
 	}
 	else
 	{
 		scrollingMap = 0;
-	}
 
-	setMouseCursor(app.mouse.button[SDL_BUTTON_LEFT] && show == SHOW_GALAXY);
+		setMouseCursor(0);
+	}
+}
+
+static void handleController(void)
+{
+	if ((app.controllerAxis[0] != 0) || (app.controllerAxis[0] != 0) || (app.controllerAxis[0] != 0) || (app.controllerAxis[0] != 0))
+	{
+		if (app.controllerX == CONTROLLER_NOINPUT)
+		{
+			app.controllerX = app.mouse.x;
+			app.controllerY = app.mouse.y;
+		}
+		app.controllerX += app.controllerAxis[0] / 4;
+		if (app.controllerX < 0)
+			app.controllerX = 0;
+		else if (app.controllerX > app.winWidth)
+			app.controllerX = app.winWidth;
+		app.uiMouse.x = app.controllerX - app.uiOffset.x;
+		app.controllerY += app.controllerAxis[1] / 4;
+		if (app.controllerY < 0)
+			app.controllerY = 0;
+		else if (app.controllerY > app.winHeight)
+			app.controllerY = app.winHeight;
+		app.uiMouse.y = app.controllerY - app.uiOffset.y;
+	}
 }
 
 static void startMission(void)

--- a/src/galaxy/galacticMap.c
+++ b/src/galaxy/galacticMap.c
@@ -868,15 +868,23 @@ static void handleController(void)
 		}
 		app.controllerX += app.controllerAxis[0] / 4;
 		if (app.controllerX < 0)
+		{
 			app.controllerX = 0;
+		}
 		else if (app.controllerX > app.winWidth)
+		{
 			app.controllerX = app.winWidth;
+		}
 		app.uiMouse.x = app.controllerX - app.uiOffset.x;
 		app.controllerY += app.controllerAxis[1] / 4;
 		if (app.controllerY < 0)
+		{
 			app.controllerY = 0;
+		}
 		else if (app.controllerY > app.winHeight)
+		{
 			app.controllerY = app.winHeight;
+		}
 		app.uiMouse.y = app.controllerY - app.uiOffset.y;
 	}
 }

--- a/src/game/credits.c
+++ b/src/game/credits.c
@@ -169,9 +169,10 @@ static void loadCredits(void)
 
 static void handleKeyboard(void)
 {
-	if (app.keyboard[SDL_SCANCODE_ESCAPE])
+	if (app.keyboard[SDL_SCANCODE_ESCAPE] || app.controllerButton[CONTROL_BOOST])
 	{
 		timeout = 0;
+		app.controllerButton[CONTROL_BOOST] = 0;
 	}
 }
 

--- a/src/game/title.c
+++ b/src/game/title.c
@@ -296,15 +296,23 @@ static void handleController(void)
 		}
 		app.controllerX += app.controllerAxis[0] / 4;
 		if (app.controllerX < 0)
+		{
 			app.controllerX = 0;
+		}
 		else if (app.controllerX > app.winWidth)
+		{
 			app.controllerX = app.winWidth;
+		}
 		app.uiMouse.x = app.controllerX - app.uiOffset.x;
 		app.controllerY += app.controllerAxis[1] / 4;
 		if (app.controllerY < 0)
+		{
 			app.controllerY = 0;
+		}
 		else if (app.controllerY > app.winHeight)
+		{
 			app.controllerY = app.winHeight;
+		}
 		app.uiMouse.y = app.controllerY - app.uiOffset.y;
 	}
 }

--- a/src/game/title.c
+++ b/src/game/title.c
@@ -57,6 +57,7 @@ extern Game    game;
 static void logic(void);
 static void draw(void);
 static void handleKeyboard(void);
+static void handleController(void);
 static void initFighters(void);
 static void doFighters(void);
 static void drawFighters(void);
@@ -153,6 +154,8 @@ static void initFighters(void)
 
 static void logic(void)
 {
+	handleController();
+
 	handleKeyboard();
 
 	scrollBackground(0, 0.25);
@@ -272,12 +275,37 @@ static void drawFighters(void)
 
 static void handleKeyboard(void)
 {
-	if (app.keyboard[SDL_SCANCODE_ESCAPE] && !app.awaitingWidgetInput)
+	if ((app.keyboard[SDL_SCANCODE_ESCAPE] || app.controllerButton[CONTROL_BOOST]) && !app.awaitingWidgetInput)
 	{
 		returnFromOptions();
 		playSound(SND_GUI_CLOSE);
 
 		clearInput();
+		app.controllerButton[CONTROL_BOOST] = 0;
+	}
+}
+
+static void handleController(void)
+{
+	if ((app.controllerAxis[0] != 0) || (app.controllerAxis[0] != 0) || (app.controllerAxis[0] != 0) || (app.controllerAxis[0] != 0))
+	{
+		if (app.controllerX == CONTROLLER_NOINPUT)
+		{
+			app.controllerX = app.mouse.x;
+			app.controllerY = app.mouse.y;
+		}
+		app.controllerX += app.controllerAxis[0] / 4;
+		if (app.controllerX < 0)
+			app.controllerX = 0;
+		else if (app.controllerX > app.winWidth)
+			app.controllerX = app.winWidth;
+		app.uiMouse.x = app.controllerX - app.uiOffset.x;
+		app.controllerY += app.controllerAxis[1] / 4;
+		if (app.controllerY < 0)
+			app.controllerY = 0;
+		else if (app.controllerY > app.winHeight)
+			app.controllerY = app.winHeight;
+		app.uiMouse.y = app.controllerY - app.uiOffset.y;
 	}
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -58,6 +58,7 @@ int main(int argc, char *argv[])
 
 	memset(&app, 0, sizeof(App));
 	memset(&dev, 0, sizeof(Dev));
+	app.controllerIndex = -1;
 
 	handleLoggingArgs(argc, argv);
 

--- a/src/main.c
+++ b/src/main.c
@@ -59,6 +59,8 @@ int main(int argc, char *argv[])
 	memset(&app, 0, sizeof(App));
 	memset(&dev, 0, sizeof(Dev));
 	app.controllerIndex = -1;
+	app.controllerX = CONTROLLER_NOINPUT;
+	app.controllerY = CONTROLLER_NOINPUT;
 
 	handleLoggingArgs(argc, argv);
 

--- a/src/structs.h
+++ b/src/structs.h
@@ -541,6 +541,8 @@ typedef struct
 	Mouse         mouse;
 	PointF        uiMouse;
 	int           keyboard[MAX_KEYBOARD_KEYS];
+	int           controllerButton[CONTROL_MAX];
+	int           controllerAxis[2];
 	SDL_Texture  *backBuffer;
 	SDL_Texture  *uiBuffer;
 	SDL_Renderer *renderer;
@@ -552,6 +554,9 @@ typedef struct
 	int           lastButtonPressed;
 	int           keyControls[CONTROL_MAX];
 	int           mouseControls[CONTROL_MAX];
+	SDL_GameController *controller;
+	int           controllerIndex;
+	int           controllerControls[CONTROL_MAX][2];
 	int           textWidth;
 } App;
 

--- a/src/structs.h
+++ b/src/structs.h
@@ -542,7 +542,10 @@ typedef struct
 	PointF        uiMouse;
 	int           keyboard[MAX_KEYBOARD_KEYS];
 	int           controllerButton[CONTROL_MAX];
-	int           controllerAxis[2];
+	int           controllerStart;
+	int           controllerAxis[4];
+	int           controllerX;
+	int           controllerY;
 	SDL_Texture  *backBuffer;
 	SDL_Texture  *uiBuffer;
 	SDL_Renderer *renderer;

--- a/src/system/controls.c
+++ b/src/system/controls.c
@@ -101,7 +101,7 @@ int isControl(int type)
 	int key = app.keyControls[type];
 	int btn = app.mouseControls[type];
 
-	return ((key != 0 && app.keyboard[key]) || (btn != 0 && app.mouse.button[btn]));
+	return ((key != 0 && app.keyboard[key]) || (btn != 0 && app.mouse.button[btn]) || (app.controller != NULL && app.controllerButton[type]));
 }
 
 int isAcceptControl(void)
@@ -123,6 +123,7 @@ void clearControl(int type)
 	{
 		app.mouse.button[btn] = 0;
 	}
+	app.controllerButton[type] = 0;
 }
 
 void resetAcceptControls(void)

--- a/src/system/init.c
+++ b/src/system/init.c
@@ -94,6 +94,7 @@ void init18N(int argc, char *argv[])
 void initSDL(int argc, char *argv[])
 {
 	int rendererFlags, windowFlags;
+	int i;
 
 	/* do this here, so we don't destroy the save dir stored in app */
 	memset(&app, 0, sizeof(App));
@@ -117,7 +118,7 @@ void initSDL(int argc, char *argv[])
 		windowFlags |= SDL_WINDOW_FULLSCREEN;
 	}
 
-	if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO) < 0)
+	if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_GAMECONTROLLER) < 0)
 	{
 		printf("Couldn't initialize SDL: %s\n", SDL_GetError());
 		exit(1);
@@ -148,6 +149,15 @@ void initSDL(int argc, char *argv[])
 	{
 		printf("Couldn't initialize SDL TTF: %s\n", SDL_GetError());
 		exit(1);
+	}
+	for (i = 0; i < SDL_NumJoysticks(); i++)
+	{
+		if (SDL_IsGameController(i))
+		{
+			app.controllerIndex = i;
+			app.controller = SDL_GameControllerOpen(i);
+			break;
+		}
 	}
 
 	app.backBuffer = SDL_CreateTexture(app.renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_TARGET, app.winWidth, app.winHeight);
@@ -276,6 +286,30 @@ static void loadConfigFile(char *filename)
 			node = node->next;
 		}
 	}
+	app.controllerControls[CONTROL_FIRE][0] = 1;
+	app.controllerControls[CONTROL_FIRE][1] = SDL_CONTROLLER_AXIS_TRIGGERRIGHT;
+	app.controllerControls[CONTROL_ACCELERATE][0] = 0;
+	app.controllerControls[CONTROL_ACCELERATE][1] = SDL_CONTROLLER_BUTTON_A;
+	app.controllerControls[CONTROL_BOOST][0] = 0;
+	app.controllerControls[CONTROL_BOOST][1] = SDL_CONTROLLER_BUTTON_B;
+	app.controllerControls[CONTROL_ECM][0] = 0;
+	app.controllerControls[CONTROL_ECM][1] = SDL_CONTROLLER_BUTTON_X;
+	app.controllerControls[CONTROL_BRAKE][0] = 0;
+	app.controllerControls[CONTROL_BRAKE][1] = SDL_CONTROLLER_BUTTON_Y;
+	app.controllerControls[CONTROL_TARGET][0] = 1;
+	app.controllerControls[CONTROL_TARGET][1] = SDL_CONTROLLER_AXIS_TRIGGERLEFT;
+	app.controllerControls[CONTROL_MISSILE][0] = 0;
+	app.controllerControls[CONTROL_MISSILE][1] = SDL_CONTROLLER_BUTTON_LEFTSHOULDER;
+	app.controllerControls[CONTROL_GUNS][0] = 0;
+	app.controllerControls[CONTROL_GUNS][1] = SDL_CONTROLLER_BUTTON_RIGHTSHOULDER;
+	app.controllerControls[CONTROL_RADAR][0] = 0;
+	app.controllerControls[CONTROL_RADAR][1] = SDL_CONTROLLER_BUTTON_DPAD_UP;
+	app.controllerControls[CONTROL_NEXT_FIGHTER][0] = 0;
+	app.controllerControls[CONTROL_NEXT_FIGHTER][1] = SDL_CONTROLLER_BUTTON_DPAD_RIGHT;
+	app.controllerControls[CONTROL_PREV_FIGHTER][0] = 0;
+	app.controllerControls[CONTROL_PREV_FIGHTER][1] = SDL_CONTROLLER_BUTTON_DPAD_LEFT;
+	app.controllerControls[CONTROL_SCREENSHOT][0] = 0;
+	app.controllerControls[CONTROL_SCREENSHOT][1] = SDL_CONTROLLER_BUTTON_BACK;
 
 	gameplayJSON = cJSON_GetObjectItem(root, "gameplay");
 	if (gameplayJSON)

--- a/src/system/init.c
+++ b/src/system/init.c
@@ -297,9 +297,13 @@ static void loadConfigFile(char *filename)
 				while (subnode)
 				{
 					if (0 == strcmp(subnode->string, "axis"))
+					{
 						app.controllerControls[i][0] = subnode->valueint;
+					}
 					else if (0 == strcmp(subnode->string, "value"))
+					{
 						app.controllerControls[i][1] = subnode->valueint;
+					}
 					subnode = subnode->next;
 				}
 

--- a/src/system/input.c
+++ b/src/system/input.c
@@ -184,7 +184,9 @@ void doControllerButtonDown(SDL_ControllerButtonEvent *event)
 			}
 		}
 		if (event->button == SDL_CONTROLLER_BUTTON_START)
+		{
 			app.controllerStart = 1;
+		}
 	}
 }
 
@@ -202,7 +204,9 @@ void doControllerButtonUp(SDL_ControllerButtonEvent *event)
 			}
 		}
 		if (event->button == SDL_CONTROLLER_BUTTON_START)
+		{
 			app.controllerStart = 0;
+		}
 	}
 }
 

--- a/src/system/input.c
+++ b/src/system/input.c
@@ -99,6 +99,8 @@ void doMouseMotion(SDL_MouseMotionEvent *event)
 {
 	app.mouse.dx = event->xrel;
 	app.mouse.dy = event->yrel;
+	app.controllerX = CONTROLLER_NOINPUT;
+	app.controllerY = CONTROLLER_NOINPUT;
 }
 
 void setMouseCursor(int isDrag)
@@ -117,7 +119,14 @@ void drawMouse(void)
 {
 	setAtlasColor(255, 255, 255, 255);
 
-	blit(mousePointer, app.mouse.x, app.mouse.y, 1);
+	if (app.controllerX != CONTROLLER_NOINPUT)
+	{
+		blit(mousePointer, app.controllerX, app.controllerY, 1);
+	}
+	else
+	{
+		blit(mousePointer, app.mouse.x, app.mouse.y, 1);
+	}
 }
 
 void doControllerAxis(SDL_ControllerAxisEvent *event)
@@ -127,11 +136,19 @@ void doControllerAxis(SDL_ControllerAxisEvent *event)
 	{
 		if (event->axis == SDL_CONTROLLER_AXIS_LEFTX)
 		{
-			app.controllerAxis[0] = event->value / 512;
+			app.controllerAxis[0] = event->value / 1024;
 		}
 		else if (event->axis == SDL_CONTROLLER_AXIS_LEFTY)
 		{
-			app.controllerAxis[1] = event->value / 512;
+			app.controllerAxis[1] = event->value / 1024;
+		}
+		else if (event->axis == SDL_CONTROLLER_AXIS_RIGHTX)
+		{
+			app.controllerAxis[2] = event->value / 1024 / 4;
+		}
+		else if (event->axis == SDL_CONTROLLER_AXIS_RIGHTY)
+		{
+			app.controllerAxis[3] = event->value / 1024 / 4;
 		}
 		else
 		{
@@ -166,6 +183,8 @@ void doControllerButtonDown(SDL_ControllerButtonEvent *event)
 				break;
 			}
 		}
+		if (event->button == SDL_CONTROLLER_BUTTON_START)
+			app.controllerStart = 1;
 	}
 }
 
@@ -182,6 +201,8 @@ void doControllerButtonUp(SDL_ControllerButtonEvent *event)
 				break;
 			}
 		}
+		if (event->button == SDL_CONTROLLER_BUTTON_START)
+			app.controllerStart = 0;
 	}
 }
 

--- a/src/system/input.c
+++ b/src/system/input.c
@@ -120,6 +120,71 @@ void drawMouse(void)
 	blit(mousePointer, app.mouse.x, app.mouse.y, 1);
 }
 
+void doControllerAxis(SDL_ControllerAxisEvent *event)
+{
+	int i;
+	if (event->which == app.controllerIndex)
+	{
+		if (event->axis == SDL_CONTROLLER_AXIS_LEFTX)
+		{
+			app.controllerAxis[0] = event->value / 512;
+		}
+		else if (event->axis == SDL_CONTROLLER_AXIS_LEFTY)
+		{
+			app.controllerAxis[1] = event->value / 512;
+		}
+		else
+		{
+			for (i = 0; i < CONTROL_MAX; i++)
+			{
+				if (app.controllerControls[i][0] == 1 && app.controllerControls[i][1] == event->axis)
+				{
+					if (event->value > 3200)
+					{
+						app.controllerButton[i] = 1;
+					}
+					else
+					{
+						app.controllerButton[i] = 0;
+					}
+				}
+			}
+		}
+	}
+}
+
+void doControllerButtonDown(SDL_ControllerButtonEvent *event)
+{
+	int i;
+	if (event->which == app.controllerIndex)
+	{
+		for (i = 0; i < CONTROL_MAX; i++)
+		{
+			if (app.controllerControls[i][0] == 0 && app.controllerControls[i][1] == event->button)
+			{
+				app.controllerButton[i] = 1;
+				break;
+			}
+		}
+	}
+}
+
+void doControllerButtonUp(SDL_ControllerButtonEvent *event)
+{
+	int i;
+	if (event->which == app.controllerIndex)
+	{
+		for (i = 0; i < CONTROL_MAX; i++)
+		{
+			if (app.controllerControls[i][0] == 0 && app.controllerControls[i][1] == event->button)
+			{
+				app.controllerButton[i] = 0;
+				break;
+			}
+		}
+	}
+}
+
 void doInput(void)
 {
 	SDL_Event event;
@@ -151,6 +216,18 @@ void doInput(void)
 
 			case SDL_KEYUP:
 				doKeyUp(&event.key);
+				break;
+
+			case SDL_CONTROLLERAXISMOTION:
+				doControllerAxis(&event.caxis);
+				break;
+
+			case SDL_CONTROLLERBUTTONDOWN:
+				doControllerButtonDown(&event.cbutton);
+				break;
+
+			case SDL_CONTROLLERBUTTONUP:
+				doControllerButtonUp(&event.cbutton);
 				break;
 
 			case SDL_QUIT:

--- a/src/system/input.c
+++ b/src/system/input.c
@@ -274,8 +274,11 @@ void doInput(void)
 	app.mouse.x = x;
 	app.mouse.y = y;
 
-	app.uiMouse.x = x - app.uiOffset.x;
-	app.uiMouse.y = y - app.uiOffset.y;
+	if (app.controllerX == CONTROLLER_NOINPUT)
+	{
+		app.uiMouse.x = x - app.uiOffset.x;
+		app.uiMouse.y = y - app.uiOffset.y;
+	}
 }
 
 void clearInput(void)

--- a/src/system/input.h
+++ b/src/system/input.h
@@ -28,4 +28,7 @@ void doMouseUp(SDL_MouseButtonEvent *event);
 void doMouseDown(SDL_MouseButtonEvent *event);
 void doKeyUp(SDL_KeyboardEvent *event);
 void doKeyDown(SDL_KeyboardEvent *event);
+void doControllerAxis(SDL_ControllerAxisEvent *event);
+void doControllerButtonUp(SDL_ControllerButtonEvent *event);
+void doControllerButtonDown(SDL_ControllerButtonEvent *event);
 void initInput(void);

--- a/src/system/widgets.c
+++ b/src/system/widgets.c
@@ -296,7 +296,7 @@ static void handleMouse(void)
 
 	if (selectedWidget && collision(selectedWidget->rect.x, selectedWidget->rect.y, selectedWidget->rect.w, selectedWidget->rect.h, app.uiMouse.x, app.uiMouse.y, 1, 1))
 	{
-		if (app.mouse.button[SDL_BUTTON_LEFT])
+		if (app.mouse.button[SDL_BUTTON_LEFT] || app.controllerButton[CONTROL_ACCELERATE])
 		{
 			switch (selectedWidget->type)
 			{
@@ -312,12 +312,14 @@ static void handleMouse(void)
 							selectedWidget = NULL;
 						}
 						app.mouse.button[SDL_BUTTON_LEFT] = 0;
+						app.controllerButton[CONTROL_ACCELERATE] = 0;
 					}
 					break;
 
 				case WT_SELECT_BUTTON:
 					changeSelectedValue(selectedWidget->parent, selectedWidget->value);
 					app.mouse.button[SDL_BUTTON_LEFT] = 0;
+					app.controllerButton[CONTROL_ACCELERATE] = 0;
 					break;
 
 				case WT_CONTROL_CONFIG:
@@ -328,6 +330,7 @@ static void handleMouse(void)
 						playSound(SND_GUI_SELECT);
 					}
 					app.mouse.button[SDL_BUTTON_LEFT] = 0;
+					app.controllerButton[CONTROL_ACCELERATE] = 0;
 					break;
 			}
 		}


### PR DESCRIPTION
When a game controller is connected, everything will work as normal. If you start moving the controller left stick, it will take over moving the mouse position until you move the real mouse. The right stick is used for scrolling on the galactic map. Fire is the right trigger. Accelerate is the A button. Boost is the B button. ECM is the X button. Brake is the Y button. Target is the left trigger. Missile is the left shoulder. Switch guns is the right shoulder. Radar is dpad up. Next and prev fighter are dpad right and left respectively. Screenshot is the back button.

Right now you can't configure the buttons through the UI.

Let me know if you want some code cleaned up or have any concerns.